### PR TITLE
Disable hostname verification

### DIFF
--- a/lib/Facebook/Graph/AccessToken.pm
+++ b/lib/Facebook/Graph/AccessToken.pm
@@ -25,6 +25,12 @@ has code => (
     required=> 1,
 );
 
+has lwp_opts => (
+    is          => 'rw',
+    predicate   => 'has_lwp_opts',
+    default     => sub { { } },
+);
+
 sub uri_as_string {
     my ($self) = @_;
     my $uri = $self->uri;
@@ -40,7 +46,7 @@ sub uri_as_string {
 
 sub request {
     my ($self) = @_;
-    my $response = LWP::UserAgent->new(ssl_opts => { verify_hostname => 0 })->get($self->uri_as_string);
+    my $response = LWP::UserAgent->new(%{ $self->lwp_opts })->get($self->uri_as_string);
     return Facebook::Graph::AccessToken::Response->new(response => $response);
 }
 

--- a/lib/Facebook/Graph/Publish.pm
+++ b/lib/Facebook/Graph/Publish.pm
@@ -22,6 +22,12 @@ has object_name => (
     default     => 'me',
 );
 
+has lwp_opts => (
+    is          => 'rw',
+    predicate   => 'has_lwp_opts',
+    default     => sub { { } },
+);
+
 sub to {
     my ($self, $object_name) = @_;
     $self->object_name($object_name);
@@ -41,7 +47,7 @@ sub publish {
     my ($self) = @_;
     my $uri = $self->uri;
     $uri->path($self->object_name.$self->object_path);
-    my $response = LWP::UserAgent->new(ssl_opts => { verify_hostname => 0 })->post($uri, $self->get_post_params);
+    my $response = LWP::UserAgent->new(%{ $self->lwp_opts })->post($uri, $self->get_post_params);
     my %params = (response => $response);
     if ($self->has_secret) {
         $params{secret} = $self->secret;

--- a/lib/Facebook/Graph/Query.pm
+++ b/lib/Facebook/Graph/Query.pm
@@ -71,6 +71,13 @@ has since => (
     predicate   => 'has_since',
 );
 
+has lwp_opts => (
+    is          => 'rw',
+    predicate   => 'has_lwp_opts',
+    default     => sub { { } },
+);
+
+
 
 sub limit_results {
     my ($self, $limit) = @_;
@@ -181,7 +188,7 @@ sub uri_as_string {
 sub request {
     my ($self, $uri) = @_;
     $uri ||= $self->uri_as_string;
-    my $response = LWP::UserAgent->new(ssl_opts => { verify_hostname => 0 })->get($uri);
+    my $response = LWP::UserAgent->new(%{ $self->lwp_opts })->get($uri);
     my %params = (response => $response);
     if ($self->has_secret) {
         $params{secret} = $self->secret;

--- a/lib/Facebook/Graph/Session.pm
+++ b/lib/Facebook/Graph/Session.pm
@@ -20,6 +20,12 @@ has sessions => (
     required=> 1,
 );
 
+has lwp_opts => (
+    is          => 'rw',
+    predicate   => 'has_lwp_opts',
+    default     => sub { { } },
+);
+
 sub uri_as_string {
     my ($self) = @_;
     my $uri = $self->uri;
@@ -35,7 +41,7 @@ sub uri_as_string {
 
 sub request {
     my ($self) = @_;
-    my $response = LWP::UserAgent->new(ssl_opts => { verify_hostname => 0 })->get($self->uri_as_string);
+    my $response = LWP::UserAgent->new(%{ $self->lwp_opts })->get($self->uri_as_string);
     return Facebook::Graph::Response->new(response => $response);
 }
 


### PR DESCRIPTION
Changes the default ssl_opts to set verify_hostname to 0.

With LWP 6.02 (and other newish LWPs, I think) errors such as these occur during the test phase of the module install:

> Could not execute request (https://graph.facebook.com/sarahbownds): Can't connect to graph.facebook.com:443 (certificate verify failed) at /root/.cpan/build/Facebook-Graph-1.0300-3d6YQe/blib/lib/Facebook/Graph/Response.pm line 39

Changing the ssl_opts to not check the hostname resolves this error.
