### PR TITLE
Added date_format option to find

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,6 @@
+1.0320 2012-01-15
+- Added date_format option into find query
+
 1.0301 2011-10-18
  - Merged custom user agent. Thanks to typester.
 

--- a/dist.ini
+++ b/dist.ini
@@ -2,8 +2,8 @@ name    = Facebook-Graph
 author  = JT Smith <jt@plainblack.com>
 license = Perl_5
 copyright_holder = Plain Black Corporation
-copyright_year   = 2010
-version = 1.0301
+copyright_year   = 2012
+version = 1.0320
 
 [@Classic]
 

--- a/lib/Facebook/Graph/Query.pm
+++ b/lib/Facebook/Graph/Query.pm
@@ -46,6 +46,12 @@ has offset => (
     predicate   => 'has_offset',
 );
 
+has datef => (
+    is          => 'rw',
+    predicate   => 'has_datef',
+);
+
+
 has search_query => (
     is          => 'rw',
     predicate   => 'has_search_query',
@@ -79,6 +85,12 @@ sub limit_results {
     my ($self, $limit) = @_;
     $self->limit($limit);
     return $self;    
+}
+
+sub date_format {
+    my ($self, $date_format) = @_;
+    $self->datef($date_format);
+    return $self;
 }
 
 sub find {
@@ -154,6 +166,9 @@ sub uri_as_string {
             $query{offset} = $self->offset;
         }
     }
+    if ($self->has_datef) {
+        $query{date_format} = $self->datef;
+    }
     if ($self->has_search_query) {
         $query{q} = $self->search_query;
         if ($self->has_search_type) {
@@ -220,6 +235,7 @@ Facebook::Graph::Query - Simple and fast searching and fetching of Facebook data
     ->where_since('1 January 2011')
     ->where_until('2 January 2011')
     ->limit(25)
+    ->date_format('U')
     ->request
     ->as_hashref;
 
@@ -321,6 +337,10 @@ See the C<context> param in the C<from> method.
 =head2 limit_results ( amount )
 
 The result set will only return a certain number of records when this is set. Useful for paging result sets. Returns C<$self> for method chaining.
+
+=head2 date_format ( format )
+
+The result set dates will be formated in the defined formats.  Specify the format by reference the PHP date format spec: L<http://php.net/manual/en/function.date.php>. (eg. ->date_format('U')->) Useful for getting epoch for datatime. Returns C<$self> for method chaining.
 
 =head3 amount
 

--- a/t/03_public_query.t
+++ b/t/03_public_query.t
@@ -1,4 +1,4 @@
-use Test::More tests => 12;
+use Test::More tests => 14;
 use lib '../lib';
 use Ouch;
 
@@ -29,3 +29,18 @@ eval { $fb->query->select_fields('')->request->as_json };
 is($@->code, 400, 'exception inherits http status code');
 is($@->message, 'Could not execute request (https://graph.facebook.com?fields=): GraphMethodException - Unsupported get request.', 'exception gives good detail');
 
+# https://www.facebook.com/events/113515098748988/
+my $f8_event = $fb->query
+  ->find('113515098748988')
+  ->request
+  ->as_hashref;
+
+like($f8_event->{start_time}, qr/\d\d\d\d-\d\d-\d\dT/, '(Default) Date Format: ISO8601' );
+
+$f8_event = $fb->query
+  ->find('113515098748988')
+  ->date_format('U')
+  ->request
+  ->as_hashref;
+
+like($f8_event->{start_time}, qr/\d\d\d\d\d\d\d\d\d\d/, 'Date Format: epoch' );


### PR DESCRIPTION
FB stores their dates in PST/PDT (depending on when the event was created) and does not add the timezone offset to the ISO8601 format.  I added the date_format option to define the format of the date.
