### PR TITLE
add ContributorsFromGit dzil plugin

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -31,3 +31,4 @@ folder = eg
 [PruneFiles]
 filenames = FacebookGraph.kpf
 
+[ContributorsFromGit]


### PR DESCRIPTION
This will add the list of contributors to the project -- as divined from the
authors of the reachable commits -- to the x_contributors metadata tag.  Other
tools and sites, like http://metacpan.org use this information to list
contributors.
