### PR TITLE
Fix failed test 'exception gives good detail'

### DIFF
--- a/t/03_public_query.t
+++ b/t/03_public_query.t
@@ -27,7 +27,7 @@ is($sarah->{metadata}{type}, 'user', 'she is a user');
 
 eval { $fb->query->select_fields('')->request->as_json };
 is($@->code, 400, 'exception inherits http status code');
-is($@->message, 'Could not execute request (https://graph.facebook.com?fields=): GraphMethodException - Unsupported get request.', 'exception gives good detail');
+like($@->message, qr#^\QCould not execute request (https://graph.facebook.com?fields=): GraphMethodException - Unsupported get request.\E#, 'exception gives good detail');
 
 is $fb->request('https://graph.facebook.com/amazon')->as_hashref->{username}, 'Amazon', 'can directly fetch a facebook graph url' ;
 


### PR DESCRIPTION
Fixes rizen/Facebook-Graph/issues#49 - it looks like Facebook just started appending "Please read the Graph API documentation at https://developers.facebook.com/docs/graph-api" to the error message. Since it's not the relevant part of the error message, ignoring it should actually make the test more robust.

With the patch:

```
# perl -I lib/ t/03_public_query.t
1..13
ok 1 - use Facebook::Graph;
ok 2 - An object of class 'Facebook::Graph' isa 'Facebook::Graph'
ok 3 - An object of class 'Facebook::Graph::Query' isa 'Facebook::Graph::Query'
ok 4 - seems to generate uris correctly
ok 5 - An object of class 'Facebook::Graph::Response' isa 'Facebook::Graph::Response'
ok 6 - got a hash ref back
ok 7 - got sarah
ok 8 - know her name
ok 9 - only fetched the things i asked for
ok 10 - she is a user
ok 11 - exception inherits http status code
ok 12 - exception gives good detail
ok 13 - can directly fetch a facebook graph url
```

Thank you for considering this pull request!
