### PR TITLE
Allow v2.3 styled /oauth/access_token response

### DIFF
--- a/lib/Facebook/Graph/AccessToken/Response.pm
+++ b/lib/Facebook/Graph/AccessToken/Response.pm
@@ -18,7 +18,13 @@ has token => (
         my $self = shift;
         my $response = $self->response;
         if ($response->is_success) {
-            return URI->new('?'.$response->content)->query_param('access_token');
+            if ($response->content =~ m/\A { .+ } \z/xm) {
+                # From v2.3 they return JSON object.
+                return JSON->new->decode($response->content)->{access_token};
+            }
+            else {
+                return URI->new('?'.$response->content)->query_param('access_token');
+            }
         }
         else {
             ouch $response->code, 'Could not fetch access token: '._retrieve_error_message($response), $response->request->uri->as_string;
@@ -33,7 +39,13 @@ has expires => (
         my $self = shift;
         my $response = $self->response;
         if ($response->is_success) {
-            return URI->new('?'.$response->content)->query_param('expires');
+            if ($response->content =~ m/\A { .+ } \z/xm) {
+                # From v2.3 they return JSON object.
+                return JSON->new->decode($response->content)->{expires_in};
+            }
+            else {
+                return URI->new('?'.$response->content)->query_param('expires');
+            }
         }
         else {
             ouch $response->code, 'Could not fetch access token: '._retrieve_error_message($response), $response->request->uri->as_string;

--- a/t/05_access_token.t
+++ b/t/05_access_token.t
@@ -1,0 +1,64 @@
+use Test::More tests => 4;
+use lib '../lib';
+use HTTP::Response;
+use JSON;
+
+use_ok('Facebook::Graph');
+use_ok('Facebook::Graph::AccessToken');
+
+my $fb = Facebook::Graph->new(
+    app_id   => 12345,
+    secret   => 'secret',
+    postback => 'https://sample.com/callback'
+);
+
+my $expires = 5183814;
+my $token   = '123456789XXXXXXXXXXX';
+
+subtest 'v2.2 or older' => sub {
+    no warnings 'redefine';
+    local *Facebook::Graph::AccessToken::request = sub {
+        return Facebook::Graph::AccessToken::Response->new(
+            response => HTTP::Response->new(
+                200,
+                'OK',
+                [
+                    'Content-Type'         => 'text/plain; charset=UTF-8',
+                    'facebook-api-version' => 'v2.2',
+                ],
+                sprintf('access_token=%s&expires=%d', $token, $expires),
+            ),
+        );
+    };
+
+    my $token_obj = $fb->request_access_token('dummy_code');
+    is($token_obj->token, $token);
+    is($token_obj->expires, $expires);
+};
+
+subtest 'v2.3 or later' => sub {
+    no warnings 'redefine';
+    local *Facebook::Graph::AccessToken::request = sub {
+        return Facebook::Graph::AccessToken::Response->new(
+            response => HTTP::Response->new(
+                200,
+                'OK',
+                [
+                    'Content-Type'         => 'text/plain; charset=UTF-8',
+                    'facebook-api-version' => 'v2.3',
+                ],
+                JSON->new->encode(+{
+                    access_token => $token,
+                    expires_in   => $expires,
+                    token_type   => 'bearer',
+                }),
+            ),
+        );
+    };
+
+    my $token_obj = $fb->request_access_token('dummy_code');
+    is($token_obj->token, $token);
+    is($token_obj->expires, $expires);
+};
+
+__END__


### PR DESCRIPTION
It's a patchy way to deal with the response from /oauth/access_token, but just might help support Graph API v2.3.