### PR TITLE
This fixes the open bug #37 on Facebook::Graph bugs list

### DIFF
--- a/lib/Facebook/Graph.pm
+++ b/lib/Facebook/Graph.pm
@@ -113,7 +113,7 @@ sub fetch {
 
 sub request {
     my ($self, $uri) = @_;
-    return Facebook::Graph::Request->new->get($uri)->recv;
+    return Facebook::Graph::Request->new->get($uri);
 }
 
 sub query {
@@ -619,7 +619,8 @@ If you were using any version of Facebook::Graph before 1.1000, then you may be 
 
 L<Moo>
 L<JSON>
-L<AnyEvent::HTTP::LWP::UserAgent>
+L<LWP::UserAgent>
+L<LWP::Protocol::https>
 L<URI>
 L<DateTime>
 L<DateTime::Format::Strptime>

--- a/lib/Facebook/Graph/AccessToken.pm
+++ b/lib/Facebook/Graph/AccessToken.pm
@@ -66,7 +66,7 @@ sub uri_as_string {
 sub request {
     my ($self) = @_;
     return Facebook::Graph::AccessToken::Response->new(
-        response => Facebook::Graph::Request->new->get($self->uri_as_string)->recv->response
+        response => Facebook::Graph::Request->new->get($self->uri_as_string)->response
     );
 }
 

--- a/lib/Facebook/Graph/BatchRequests.pm
+++ b/lib/Facebook/Graph/BatchRequests.pm
@@ -40,7 +40,7 @@ sub request {
     $self->requests([]); # reset
 
     my $uri = "https://graph.facebook.com";
-    my $resp = Facebook::Graph::Request->new->post($uri, $post)->recv->response;
+    my $resp = Facebook::Graph::Request->new->post($uri, $post)->response;
     
     unless ($resp->is_success) {
         my $message = $resp->message;

--- a/lib/Facebook/Graph/Publish.pm
+++ b/lib/Facebook/Graph/Publish.pm
@@ -3,7 +3,7 @@ package Facebook::Graph::Publish;
 use Moo;
 use Facebook::Graph::Request;
 with 'Facebook::Graph::Role::Uri';
-use AnyEvent::HTTP::LWP::UserAgent;
+use LWP::UserAgent;
 use URI::Escape;
 
 has secret => (
@@ -41,7 +41,7 @@ sub publish {
     my ($self) = @_;
     my $uri = $self->uri;
     $uri->path($self->generate_versioned_path($self->object_name.$self->object_path));
-    return Facebook::Graph::Request->new->post($uri, $self->get_post_params)->recv;
+    return Facebook::Graph::Request->new->post($uri, $self->get_post_params);
 }
 
 1;

--- a/lib/Facebook/Graph/Query.pm
+++ b/lib/Facebook/Graph/Query.pm
@@ -193,7 +193,7 @@ sub uri_as_string {
 
 sub request {
     my ($self) = @_;
-    return Facebook::Graph::Request->new->get($self->uri_as_string)->recv;
+    return Facebook::Graph::Request->new->get($self->uri_as_string);
 }
 
 1;

--- a/lib/Facebook/Graph/Session.pm
+++ b/lib/Facebook/Graph/Session.pm
@@ -34,7 +34,7 @@ sub uri_as_string {
 
 sub request {
     my ($self) = @_;
-    return Facebook::Graph::Request->new->get($self->uri_as_string)->recv;
+    return Facebook::Graph::Request->new->get($self->uri_as_string);
 }
 
 1;


### PR DESCRIPTION
Fix socket leak: Replace AnyEvent::HTTP::LWP::UserAgent with LWP::UserAgent

The reason to replace AnyEvent and AnyEvent::HTTP::LWP::UserAgent based
requests with LWP::UserAgent, is because of stability. It seems that at least
on certain Linux systems AnyEvent::HTTP::LWP::UserAgent starts to leak
sockets. The socket leak will lead, that all the responses will start to fail.

The failure error message is "Could not fetch access token: No such device
or address at /app/local/lib/perl5/Facebook/Graph/AccessToken/Response.pm
line 24." - which doesn't tell that much, but is related that the request did
never leave, because opening a socket failed.

It would be nice to fix AnyEvent::HTTP::LWP::UserAgent in general for the
actual socket leak problem, but as the Facebook::Graph module is a dependency
for quite many business applications - it's imperative to use a stable HTTP
client. And as the Facebook::Graph module does not actually do anything
asynchronously, it's not required to use an async HTTP client - at least for
now.