### PR TITLE
Add initial Travis-CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,20 @@
+sudo: false
+
+language: perl
+
+perl:
+    - "5.26"
+    - "5.24"
+    - "5.22"
+    - "5.20"
+    - "5.18"
+    - "5.16"
+    - "5.14"
+    - "5.12"
+
+install:
+    - dzil authordeps --missing | cpanm --no-skip-satisfied --notest || { cat ~/.cpanm/build.log ; false ; }
+    - dzil listdeps --author --missing | cpanm --no-skip-satisfied --notest || { cat ~/.cpanm/build.log ; false ; }
+
+script:
+    - dzil test --author --release


### PR DESCRIPTION
[Travis-CI](https://travis-ci.org) is a continuous integration service that is free for open source projects.  This patch adds an initial working configuration for this dist: in other words, the dependencies are installed correctly and the tests all pass.

This PR is submitted in the hope that it is helpful.  If you want anything changed I'll gladly update it and resubmit as necessary.