### PR TITLE
Add initial AppVeyor configuration

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,15 @@
+cache:
+    - C:\Strawberry -> .appveyor_clear_cache.txt
+
+shallow_clone: true
+
+install:
+  - if not exist "C:\Strawberry" cinst strawberryperl
+  - set PATH=C:\strawberry\perl\bin;C:\strawberry\perl\site\bin;C:\strawberry\c\bin;%PATH%
+  - cd %APPVEYOR_BUILD_FOLDER%
+  - cpanm --notest Dist::Zilla
+  - dzil authordeps --missing | cpanm --notest || type C:\Users\appveyor\.cpanm\build.log ; perl -e "exit 1"
+  - dzil listdeps --author --missing | cpanm --notest || type C:\Users\appveyor\.cpanm\build.log ; perl -e "exit 1"
+
+build_script:
+  - dzil test --author --release


### PR DESCRIPTION
[AppVeyor](https://ci.appveyor.com) is a continuous integration service like Travis-CI, however it allows one to test distributions on Windows systems.  This patch provides an initial, working configuration where all tests pass.

This PR is submitted in the hope that it is useful.  If you want anything changed, please just let me know and I'll be happy to update and resubmit as necessary.