### PR TITLE
Set minimum Perl version explicitly

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -31,6 +31,7 @@ repository.web    = http://github.com/rizen/Facebook-Graph
 repository.type   = git
 
 [Prereqs]
+perl = 5.006
 Moo = 0
 JSON = 2.16
 Test::More = 0

--- a/lib/Facebook/Graph.pm
+++ b/lib/Facebook/Graph.pm
@@ -1,6 +1,7 @@
 package Facebook::Graph;
 
 use Moo;
+use 5.006;
 use MIME::Base64::URLSafe;
 use JSON;
 use Facebook::Graph::AccessToken;


### PR DESCRIPTION
`Perl::MinimumVersion` shows that the minimum syntax of the code is Perl
5.6.0 and it is considered good practice to include this information
explicitly in the dist code, hence the addition of the Perl version in
this change.

If you want to have this pull request updated in any way, please just let me know and I'll update and resubmit as appropriate.