### PR TITLE
Use strict and warnings pragmas in tests

### DIFF
--- a/author.t/authenticate.t
+++ b/author.t/authenticate.t
@@ -1,5 +1,7 @@
-use Test::More;
 use strict;
+use warnings;
+
+use Test::More;
 use lib '../lib';
 
 die "You need to set an environment variable for FB_APP_ID && FB_SECRET to test this" unless $ENV{FB_APP_ID} && $ENV{FB_SECRET};

--- a/author.t/batch_requests.t
+++ b/author.t/batch_requests.t
@@ -1,3 +1,6 @@
+use strict;
+use warnings;
+
 use Test::More tests => 3;
 use lib '../lib';
 use Ouch;

--- a/author.t/private_fetch.t
+++ b/author.t/private_fetch.t
@@ -1,3 +1,6 @@
+use strict;
+use warnings;
+
 use Test::More tests => 4;
 use lib '../lib';
 

--- a/author.t/private_query.t
+++ b/author.t/private_query.t
@@ -1,3 +1,6 @@
+use strict;
+use warnings;
+
 use Test::More;
 use lib '../lib';
 use Ouch;

--- a/author.t/publish_comment.t
+++ b/author.t/publish_comment.t
@@ -1,3 +1,6 @@
+use strict;
+use warnings;
+
 use Test::More;
 use lib '../lib';
 

--- a/author.t/publish_post.t
+++ b/author.t/publish_post.t
@@ -1,3 +1,6 @@
+use strict;
+use warnings;
+
 use Test::More tests => 4;
 use lib '../lib';
 

--- a/author.t/publish_to_feed.t
+++ b/author.t/publish_to_feed.t
@@ -1,3 +1,6 @@
+use strict;
+use warnings;
+
 use Test::More tests => 8;
 use lib '../lib';
 

--- a/author.t/rsvp_attending.t
+++ b/author.t/rsvp_attending.t
@@ -1,3 +1,6 @@
+use strict;
+use warnings;
+
 use Test::More tests => 3;
 use lib '../lib';
 

--- a/author.t/rsvp_declined.t
+++ b/author.t/rsvp_declined.t
@@ -1,3 +1,6 @@
+use strict;
+use warnings;
+
 use Test::More tests => 3;
 use lib '../lib';
 

--- a/author.t/rsvp_maybe.t
+++ b/author.t/rsvp_maybe.t
@@ -1,3 +1,6 @@
+use strict;
+use warnings;
+
 use Test::More tests => 3;
 use lib '../lib';
 

--- a/t/01_versioned_path.t
+++ b/t/01_versioned_path.t
@@ -1,3 +1,6 @@
+use strict;
+use warnings;
+
 use Test::More tests => 5;
 use lib '../lib';
 

--- a/t/02_signed_requests.t
+++ b/t/02_signed_requests.t
@@ -1,3 +1,6 @@
+use strict;
+use warnings;
+
 use Test::More tests => 3;
 use lib '../lib';
 use JSON;

--- a/t/04_picture.t
+++ b/t/04_picture.t
@@ -1,3 +1,6 @@
+use strict;
+use warnings;
+
 use Test::More tests => 7;
 use lib '../lib';
 

--- a/t/05_access_token.t
+++ b/t/05_access_token.t
@@ -1,3 +1,6 @@
+use strict;
+use warnings;
+
 use Test::More tests => 4;
 use lib '../lib';
 use HTTP::Response;


### PR DESCRIPTION
It's considered good practice to use the `strict` and `warnings` pragmas to Perl source code files, hence they were added to files missing the pragmas.  Since the missing pragmas were distributed between the `t` and `author.t` directories, the changes were submitted in two commits, one for each directory (just in case you want to cherry-pick the commits).  If you want the commits merged, just let me know and I'll make the change and resubmit the PR.