### PR TITLE
Bump copyright year to current release year

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -2,7 +2,7 @@ name    = Facebook-Graph
 author  = JT Smith <jt@plainblack.com>
 license = Perl_5
 copyright_holder = Plain Black Corporation
-copyright_year   = 2014
+copyright_year   = 2017
 version = 1.1204
 
 [GatherDir]

--- a/lib/Facebook/Graph.pm
+++ b/lib/Facebook/Graph.pm
@@ -605,7 +605,7 @@ JT Smith <jt_at_plainblack_dot_com>
 
 =head1 LEGAL
 
-Facebook::Graph is Copyright 2010 - 2012 Plain Black Corporation (L<http://www.plainblack.com>) and is licensed under the same terms as Perl itself.
+Facebook::Graph is Copyright 2010 - 2017 Plain Black Corporation (L<http://www.plainblack.com>) and is licensed under the same terms as Perl itself.
 
 =cut
 

--- a/lib/Facebook/Graph/AccessToken.pm
+++ b/lib/Facebook/Graph/AccessToken.pm
@@ -140,6 +140,6 @@ Checks for either access_token or code and dies if has neither.
 
 =head1 LEGAL
 
-Facebook::Graph is Copyright 2010 - 2012 Plain Black Corporation (L<http://www.plainblack.com>) and is licensed under the same terms as Perl itself.
+Facebook::Graph is Copyright 2010 - 2017 Plain Black Corporation (L<http://www.plainblack.com>) and is licensed under the same terms as Perl itself.
 
 =cut

--- a/lib/Facebook/Graph/AccessToken/Response.pm
+++ b/lib/Facebook/Graph/AccessToken/Response.pm
@@ -90,7 +90,7 @@ Direct access to the L<HTTP::Response> object.
 
 =head1 LEGAL
 
-Facebook::Graph is Copyright 2010 - 2012 Plain Black Corporation (L<http://www.plainblack.com>) and is licensed under the same terms as Perl itself.
+Facebook::Graph is Copyright 2010 - 2017 Plain Black Corporation (L<http://www.plainblack.com>) and is licensed under the same terms as Perl itself.
 
 =cut
 

--- a/lib/Facebook/Graph/Authorize.pm
+++ b/lib/Facebook/Graph/Authorize.pm
@@ -119,6 +119,6 @@ Returns a URI string to redirect the user back to Facebook.
 
 =head1 LEGAL
 
-Facebook::Graph is Copyright 2010 - 2012 Plain Black Corporation (L<http://www.plainblack.com>) and is licensed under the same terms as Perl itself.
+Facebook::Graph is Copyright 2010 - 2017 Plain Black Corporation (L<http://www.plainblack.com>) and is licensed under the same terms as Perl itself.
 
 =cut

--- a/lib/Facebook/Graph/BatchRequests.pm
+++ b/lib/Facebook/Graph/BatchRequests.pm
@@ -115,6 +115,6 @@ Fire the request and return decoded @batches data
 
 =head1 LEGAL
 
-Facebook::Graph is Copyright 2010 - 2012 Plain Black Corporation (L<http://www.plainblack.com>) and is licensed under the same terms as Perl itself.
+Facebook::Graph is Copyright 2010 - 2017 Plain Black Corporation (L<http://www.plainblack.com>) and is licensed under the same terms as Perl itself.
 
 =cut

--- a/lib/Facebook/Graph/Cookbook.pod
+++ b/lib/Facebook/Graph/Cookbook.pod
@@ -27,6 +27,6 @@ Shows you how to post as all the different pages under your control.
 
 =head1 LEGAL
 
-Facebook::Graph is Copyright 2010 - 2012 Plain Black Corporation (L<http://www.plainblack.com>) and is licensed under the same terms as Perl itself.
+Facebook::Graph is Copyright 2010 - 2017 Plain Black Corporation (L<http://www.plainblack.com>) and is licensed under the same terms as Perl itself.
 
 =cut

--- a/lib/Facebook/Graph/Cookbook/Recipe1.pod
+++ b/lib/Facebook/Graph/Cookbook/Recipe1.pod
@@ -199,6 +199,6 @@ For more recipes, check out the L<Facebook::Graph::Cookbook>.
 
 =head1 LEGAL
 
-Facebook::Graph is Copyright 2010 - 2012 Plain Black Corporation (L<http://www.plainblack.com>) and is licensed under the same terms as Perl itself.
+Facebook::Graph is Copyright 2010 - 2017 Plain Black Corporation (L<http://www.plainblack.com>) and is licensed under the same terms as Perl itself.
 
 =cut

--- a/lib/Facebook/Graph/Cookbook/Recipe2.pod
+++ b/lib/Facebook/Graph/Cookbook/Recipe2.pod
@@ -95,6 +95,6 @@ For more recipes, check out the L<Facebook::Graph::Cookbook>.
 
 =head1 LEGAL
 
-Facebook::Graph is Copyright 2010 - 2012 Plain Black Corporation (L<http://www.plainblack.com>) and is licensed under the same terms as Perl itself.
+Facebook::Graph is Copyright 2010 - 2017 Plain Black Corporation (L<http://www.plainblack.com>) and is licensed under the same terms as Perl itself.
 
 =cut

--- a/lib/Facebook/Graph/Cookbook/Recipe3.pod
+++ b/lib/Facebook/Graph/Cookbook/Recipe3.pod
@@ -51,6 +51,6 @@ For more recipes, check out the L<Facebook::Graph::Cookbook>.
 
 =head1 LEGAL
 
-Facebook::Graph is Copyright 2010 - 2012 Plain Black Corporation (L<http://www.plainblack.com>) and is licensed under the same terms as Perl itself.
+Facebook::Graph is Copyright 2010 - 2017 Plain Black Corporation (L<http://www.plainblack.com>) and is licensed under the same terms as Perl itself.
 
 =cut

--- a/lib/Facebook/Graph/Page/Feed.pm
+++ b/lib/Facebook/Graph/Page/Feed.pm
@@ -200,7 +200,7 @@ Posts the data and returns a L<Facebook::Graph::Response> object. The response o
  
 =head1 LEGAL
 
-Facebook::Graph is Copyright 2010 - 2012 Plain Black Corporation (L<http://www.plainblack.com>) and is licensed under the same terms as Perl itself.
+Facebook::Graph is Copyright 2010 - 2017 Plain Black Corporation (L<http://www.plainblack.com>) and is licensed under the same terms as Perl itself.
 
 Facebook::Graph::Page::Feed is Copyright 2014 Alexandr Evstigneev (L<http://evstigneev.com>) and is licensed under the same terms as Perl itself.
 

--- a/lib/Facebook/Graph/Picture.pm
+++ b/lib/Facebook/Graph/Picture.pm
@@ -129,6 +129,6 @@ Returns a URI string based upon all the methods you've called so far on the quer
 
 =head1 LEGAL
 
-Facebook::Graph is Copyright 2010 - 2012 Plain Black Corporation (L<http://www.plainblack.com>) and is licensed under the same terms as Perl itself.
+Facebook::Graph is Copyright 2010 - 2017 Plain Black Corporation (L<http://www.plainblack.com>) and is licensed under the same terms as Perl itself.
 
 =cut

--- a/lib/Facebook/Graph/Publish.pm
+++ b/lib/Facebook/Graph/Publish.pm
@@ -56,6 +56,6 @@ This module shouldn't be used by you directly for any purpose.
 
 =head1 LEGAL
 
-Facebook::Graph is Copyright 2010 - 2012 Plain Black Corporation (L<http://www.plainblack.com>) and is licensed under the same terms as Perl itself.
+Facebook::Graph is Copyright 2010 - 2017 Plain Black Corporation (L<http://www.plainblack.com>) and is licensed under the same terms as Perl itself.
 
 =cut

--- a/lib/Facebook/Graph/Publish/Checkin.pm
+++ b/lib/Facebook/Graph/Publish/Checkin.pm
@@ -176,6 +176,6 @@ Posts the data and returns a L<Facebook::Graph::Response> object. The response o
 
 =head1 LEGAL
 
-Facebook::Graph is Copyright 2010 - 2012 Plain Black Corporation (L<http://www.plainblack.com>) and is licensed under the same terms as Perl itself.
+Facebook::Graph is Copyright 2010 - 2017 Plain Black Corporation (L<http://www.plainblack.com>) and is licensed under the same terms as Perl itself.
 
 =cut

--- a/lib/Facebook/Graph/Publish/Comment.pm
+++ b/lib/Facebook/Graph/Publish/Comment.pm
@@ -69,6 +69,6 @@ Posts the data and returns a L<Facebook::Graph::Response> object. The response o
 
 =head1 LEGAL
 
-Facebook::Graph is Copyright 2010 - 2012 Plain Black Corporation (L<http://www.plainblack.com>) and is licensed under the same terms as Perl itself.
+Facebook::Graph is Copyright 2010 - 2017 Plain Black Corporation (L<http://www.plainblack.com>) and is licensed under the same terms as Perl itself.
 
 =cut

--- a/lib/Facebook/Graph/Publish/PageTab.pm
+++ b/lib/Facebook/Graph/Publish/PageTab.pm
@@ -50,6 +50,6 @@ Posts the data and returns a L<Facebook::Graph::Response> object. The response o
 
 =head1 LEGAL
 
-Facebook::Graph is Copyright 2010 - 2012 Plain Black Corporation (L<http://www.plainblack.com>) and is licensed under the same terms as Perl itself.
+Facebook::Graph is Copyright 2010 - 2017 Plain Black Corporation (L<http://www.plainblack.com>) and is licensed under the same terms as Perl itself.
 
 =cut

--- a/lib/Facebook/Graph/Publish/Photo.pm
+++ b/lib/Facebook/Graph/Publish/Photo.pm
@@ -85,6 +85,6 @@ Posts the data and returns a L<Facebook::Graph::Response> object. The response o
 
 =head1 LEGAL
 
-Facebook::Graph is Copyright 2010 - 2012 Plain Black Corporation (L<http://www.plainblack.com>) and is licensed under the same terms as Perl itself.
+Facebook::Graph is Copyright 2010 - 2017 Plain Black Corporation (L<http://www.plainblack.com>) and is licensed under the same terms as Perl itself.
 
 =cut

--- a/lib/Facebook/Graph/Publish/Post.pm
+++ b/lib/Facebook/Graph/Publish/Post.pm
@@ -465,6 +465,6 @@ Posts the data and returns a L<Facebook::Graph::Response> object. The response o
 
 =head1 LEGAL
 
-Facebook::Graph is Copyright 2010 - 2012 Plain Black Corporation (L<http://www.plainblack.com>) and is licensed under the same terms as Perl itself.
+Facebook::Graph is Copyright 2010 - 2017 Plain Black Corporation (L<http://www.plainblack.com>) and is licensed under the same terms as Perl itself.
 
 =cut

--- a/lib/Facebook/Graph/Publish/RSVPAttending.pm
+++ b/lib/Facebook/Graph/Publish/RSVPAttending.pm
@@ -33,6 +33,6 @@ Posts the data and returns a L<Facebook::Graph::Response> object. The response o
 
 =head1 LEGAL
 
-Facebook::Graph is Copyright 2010 - 2012 Plain Black Corporation (L<http://www.plainblack.com>) and is licensed under the same terms as Perl itself.
+Facebook::Graph is Copyright 2010 - 2017 Plain Black Corporation (L<http://www.plainblack.com>) and is licensed under the same terms as Perl itself.
 
 =cut

--- a/lib/Facebook/Graph/Publish/RSVPDeclined.pm
+++ b/lib/Facebook/Graph/Publish/RSVPDeclined.pm
@@ -33,6 +33,6 @@ Posts the data and returns a L<Facebook::Graph::Response> object. The response o
 
 =head1 LEGAL
 
-Facebook::Graph is Copyright 2010 - 2012 Plain Black Corporation (L<http://www.plainblack.com>) and is licensed under the same terms as Perl itself.
+Facebook::Graph is Copyright 2010 - 2017 Plain Black Corporation (L<http://www.plainblack.com>) and is licensed under the same terms as Perl itself.
 
 =cut

--- a/lib/Facebook/Graph/Publish/RSVPMaybe.pm
+++ b/lib/Facebook/Graph/Publish/RSVPMaybe.pm
@@ -33,6 +33,6 @@ Posts the data and returns a L<Facebook::Graph::Response> object. The response o
 
 =head1 LEGAL
 
-Facebook::Graph is Copyright 2010 - 2012 Plain Black Corporation (L<http://www.plainblack.com>) and is licensed under the same terms as Perl itself.
+Facebook::Graph is Copyright 2010 - 2017 Plain Black Corporation (L<http://www.plainblack.com>) and is licensed under the same terms as Perl itself.
 
 =cut

--- a/lib/Facebook/Graph/Query.pm
+++ b/lib/Facebook/Graph/Query.pm
@@ -410,6 +410,6 @@ Optionally pass in your own URI string and all the other options will be ignored
 
 =head1 LEGAL
 
-Facebook::Graph is Copyright 2010 - 2012 Plain Black Corporation (L<http://www.plainblack.com>) and is licensed under the same terms as Perl itself.
+Facebook::Graph is Copyright 2010 - 2017 Plain Black Corporation (L<http://www.plainblack.com>) and is licensed under the same terms as Perl itself.
 
 =cut

--- a/lib/Facebook/Graph/Request.pm
+++ b/lib/Facebook/Graph/Request.pm
@@ -91,7 +91,7 @@ A URI to fetch.
 
 =head1 LEGAL
 
-Facebook::Graph is Copyright 2010 - 2012 Plain Black Corporation (L<http://www.plainblack.com>) and is licensed under the same terms as Perl itself.
+Facebook::Graph is Copyright 2010 - 2017 Plain Black Corporation (L<http://www.plainblack.com>) and is licensed under the same terms as Perl itself.
 
 =cut
 

--- a/lib/Facebook/Graph/Response.pm
+++ b/lib/Facebook/Graph/Response.pm
@@ -80,7 +80,7 @@ Direct access to the L<HTTP::Response> object.
 
 =head1 LEGAL
 
-Facebook::Graph is Copyright 2010 - 2012 Plain Black Corporation (L<http://www.plainblack.com>) and is licensed under the same terms as Perl itself.
+Facebook::Graph is Copyright 2010 - 2017 Plain Black Corporation (L<http://www.plainblack.com>) and is licensed under the same terms as Perl itself.
 
 =cut
 

--- a/lib/Facebook/Graph/Role/Uri.pm
+++ b/lib/Facebook/Graph/Role/Uri.pm
@@ -30,7 +30,7 @@ Provides a C<uri> method in any class which returns a L<URI> object that points 
 
 =head1 LEGAL
 
-Facebook::Graph is Copyright 2010 - 2012 Plain Black Corporation (L<http://www.plainblack.com>) and is licensed under the same terms as Perl itself.
+Facebook::Graph is Copyright 2010 - 2017 Plain Black Corporation (L<http://www.plainblack.com>) and is licensed under the same terms as Perl itself.
 
 =cut
 

--- a/lib/Facebook/Graph/Session.pm
+++ b/lib/Facebook/Graph/Session.pm
@@ -71,6 +71,6 @@ Makes a request to Facebook to fetch an access token. Returns a L<Facebook::Grap
 
 =head1 LEGAL
 
-Facebook::Graph is Copyright 2010 - 2012 Plain Black Corporation (L<http://www.plainblack.com>) and is licensed under the same terms as Perl itself.
+Facebook::Graph is Copyright 2010 - 2017 Plain Black Corporation (L<http://www.plainblack.com>) and is licensed under the same terms as Perl itself.
 
 =cut


### PR DESCRIPTION
The current release year is 2017, hence why the copyright year information was changed to this value.  If you want me to bump this value to (say) 2018, then please just let me know and I'll update the code and resubmit the PR.