### PR TITLE
Add info about provided packages to dist metadata

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -10,6 +10,7 @@ version = 1.1204
 [ManifestSkip]
 [MetaYAML]
 [MetaJSON]
+[MetaProvides::Package]
 [License]
 [Readme]
 [PkgVersion]


### PR DESCRIPTION
This change addresses the [meta_yml_has_provides](https://cpants.cpanauthors.org/kwalitee/meta_yml_has_provides) CPANTS kwalitee issue.