### PR TITLE
Add BuildRequires info to dist metadata

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -42,6 +42,10 @@ DateTime::Format::Strptime = 1.4000
 MIME::Base64::URLSafe = 0.01
 Ouch = 0.0400
 
+[Prereqs / BuildRequires]
+HTTP::Response = 0
+Test::Pod = 0
+
 [MetaNoIndex]
 folder = author.t
 folder = eg


### PR DESCRIPTION
This change addresses the [build_prereq_matches_use](https://cpants.cpanauthors.org/kwalitee/build_prereq_matches_use) CPANTS kwalitee issue.